### PR TITLE
feat(clam): inscrição nos processos seletivos das ligas acadêmicas

### DIFF
--- a/app/coordenadorias/clam/page.tsx
+++ b/app/coordenadorias/clam/page.tsx
@@ -32,6 +32,26 @@ export default async function CLAMPage() {
           description="Abra cada grupo para navegar pelas ligas vinculadas à CLAM e seguir para a página detalhada de cada uma."
         />
 
+        <Link
+          href="/processos-seletivos"
+          className="glass-panel surface-outline flex flex-col gap-3 rounded-[28px] border border-white/70 p-6 transition-transform duration-300 hover:-translate-y-0.5 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <span>
+            <span className="block text-xs font-semibold uppercase tracking-[0.28em] text-blue-600">
+              Inscricoes
+            </span>
+            <span className="mt-2 block text-2xl font-semibold text-slate-950 dark:text-white">
+              Processos seletivos das ligas
+            </span>
+            <span className="mt-2 block text-sm leading-7 text-slate-600 dark:text-slate-300">
+              Veja os editais abertos, faca sua inscricao e escolha as ligas em que quer concorrer.
+            </span>
+          </span>
+          <span className="inline-flex w-max items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white">
+            Ver processos seletivos
+          </span>
+        </Link>
+
         <div className="grid gap-5 xl:grid-cols-2">
           {leagueGroups.map((group) => {
             const items = leagues.filter((league) => league.type === group.key);

--- a/app/panel/page.tsx
+++ b/app/panel/page.tsx
@@ -7,6 +7,7 @@ export default function PanelPage() {
             <p className="max-w-2xl text-slate-600 dark:text-slate-300">Acesse suas inscrições, histórico de eventos, certificados e artigos salvos.</p>
             <div className="flex flex-wrap gap-3">
                 <Link href="/panel/eventos/inscricoes" className="rounded-xl bg-blue-600 px-5 py-3 font-semibold text-white">Gerenciar eventos</Link>
+                <Link href="/processos-seletivos" className="rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700">Processos seletivos</Link>
                 <Link href="/perfil" className="rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700">Abrir perfil</Link>
             </div>
         </main>

--- a/app/processos-seletivos/[id]/inscricao/page.tsx
+++ b/app/processos-seletivos/[id]/inscricao/page.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useUser } from "@auth0/nextjs-auth0";
+import { ArrowLeft, CreditCard, Loader2, LogIn, ShieldCheck } from "lucide-react";
+import {
+  describeError,
+  formatCurrency,
+  formatDateTime,
+  type StudentApplicationState,
+} from "../../types";
+
+type PayerForm = {
+  name: string;
+  cpf: string;
+  zipCode: string;
+  street: string;
+  number: string;
+  neighborhood: string;
+  complement: string;
+  phone: string;
+  email: string;
+};
+
+const EMPTY_PAYER: PayerForm = {
+  name: "",
+  cpf: "",
+  zipCode: "",
+  street: "",
+  number: "",
+  neighborhood: "",
+  complement: "",
+  phone: "",
+  email: "",
+};
+
+export default function SelectionProcessCheckoutPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const processId = params?.id ?? "";
+  const { user, isLoading: isUserLoading } = useUser();
+
+  const [state, setState] = useState<StudentApplicationState | null>(null);
+  const [payer, setPayer] = useState<PayerForm>(EMPTY_PAYER);
+  const [examsCount, setExamsCount] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    if (!processId || !user) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError("");
+
+    try {
+      const response = await fetch(`/api/v1/selective-processes/${processId}/me`, { cache: "no-store" });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok || !body?.success) {
+        throw new Error(describeError(body?.error, "Não foi possível carregar sua inscrição."));
+      }
+
+      const data = body.data as StudentApplicationState;
+      setState(data);
+
+      if (data.status === "PAID_PENDING_LEAGUES" || data.status === "ENROLLED") {
+        router.replace(`/processos-seletivos/${processId}/painel`);
+      }
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Erro ao carregar sua inscrição.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [processId, user, router]);
+
+  useEffect(() => {
+    if (!isUserLoading) void load();
+  }, [isUserLoading, load]);
+
+  useEffect(() => {
+    if (user?.email && !payer.email) setPayer((previous) => ({ ...previous, email: user.email as string }));
+    if (user?.name && !payer.name) setPayer((previous) => ({ ...previous, name: user.name as string }));
+  }, [user, payer.email, payer.name]);
+
+  const price = useMemo(() => {
+    const tiers = state?.process.pricingTiers ?? [];
+    const exact = tiers.find((tier) => tier.examsCount === examsCount);
+    if (exact) return exact.unitTotalPrice;
+
+    const single = tiers.find((tier) => tier.examsCount === 1);
+    return single ? single.unitTotalPrice * examsCount : null;
+  }, [state, examsCount]);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError("");
+
+    try {
+      const response = await fetch(`/api/v1/selective-processes/${processId}/checkout`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ examsCount, payer }),
+      });
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok || !body?.success) {
+        throw new Error(describeError(body?.error, "Não foi possível iniciar o pagamento."));
+      }
+
+      window.location.href = body.data.init_point as string;
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : "Erro ao iniciar o pagamento.");
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isUserLoading || isLoading) {
+    return (
+      <main className="flex min-h-screen items-center justify-center pt-24">
+        <Loader2 className="h-10 w-10 animate-spin text-blue-600" aria-label="Carregando inscrição" />
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="page-shell flex min-h-screen flex-col items-center justify-center gap-5 text-center">
+        <LogIn className="h-12 w-12 text-blue-600" />
+        <h1 className="text-3xl font-bold text-slate-950 dark:text-white">Entre para se inscrever</h1>
+        <a
+          href={`/auth/login?returnTo=${encodeURIComponent(`/processos-seletivos/${processId}/inscricao`)}`}
+          className="rounded-2xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white"
+        >
+          Fazer login
+        </a>
+      </main>
+    );
+  }
+
+  const inputClass =
+    "w-full rounded-2xl border border-white/70 bg-white/85 px-4 py-3 text-sm text-slate-800 outline-none focus:ring-2 focus:ring-blue-600 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100";
+
+  const maxExams = state?.process.maxExamsPerApplication ?? 1;
+
+  return (
+    <main className="page-shell min-h-screen space-y-8 pb-16 pt-28">
+      <Link
+        href={`/processos-seletivos/${processId}`}
+        className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600"
+      >
+        <ArrowLeft className="h-4 w-4" /> Voltar ao processo seletivo
+      </Link>
+
+      <header className="glass-panel-strong rounded-3xl border border-white/80 p-6 dark:border-white/10 sm:p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-blue-600">Inscrição</p>
+        <h1 className="mt-2 text-3xl font-bold text-slate-950 dark:text-white">Pagamento da inscrição</h1>
+        <p className="mt-3 max-w-3xl leading-7 text-slate-600 dark:text-slate-300">
+          Escolha por quantas ligas você quer concorrer e informe os dados de cobrança. O pagamento é
+          processado pelo Mercado Pago; as ligas são selecionadas depois da confirmação.
+        </p>
+      </header>
+
+      {state?.payment && (
+        <section className="rounded-[28px] border border-amber-200 bg-amber-50 p-6 dark:border-amber-900/50 dark:bg-amber-950/30">
+          <h2 className="text-lg font-semibold text-amber-800 dark:text-amber-200">
+            Você já tem um pagamento em aberto
+          </h2>
+          <p className="mt-1 text-sm text-amber-700 dark:text-amber-300">
+            O link vale até {formatDateTime(state.payment.expiresAt)}.
+          </p>
+          <a
+            href={state.payment.init_point}
+            className="mt-4 inline-flex items-center gap-2 rounded-2xl bg-amber-600 px-5 py-3 text-sm font-semibold text-white"
+          >
+            <CreditCard className="h-4 w-4" /> Retomar pagamento
+          </a>
+        </section>
+      )}
+
+      {error && (
+        <p className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-medium text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+          {error}
+        </p>
+      )}
+
+      <form onSubmit={submit} className="space-y-6">
+        <section className="glass-panel surface-outline space-y-4 rounded-[28px] border border-white/70 p-6 dark:border-white/10">
+          <h2 className="text-xl font-semibold text-slate-950 dark:text-white">Quantas ligas você quer disputar?</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Este processo seletivo permite até {maxExams} liga{maxExams === 1 ? "" : "s"} por inscrição.
+          </p>
+
+          <div className="flex flex-wrap gap-3">
+            {Array.from({ length: maxExams }, (_, index) => index + 1).map((count) => (
+              <button
+                type="button"
+                key={count}
+                onClick={() => setExamsCount(count)}
+                className={`rounded-2xl border px-5 py-3 text-sm font-semibold transition-colors ${
+                  examsCount === count
+                    ? "border-blue-600 bg-blue-600 text-white"
+                    : "border-white/70 bg-white/80 text-slate-700 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-200"
+                }`}
+              >
+                {count} liga{count === 1 ? "" : "s"}
+              </button>
+            ))}
+          </div>
+
+          <p className="text-lg font-bold text-slate-900 dark:text-white">
+            {price === null ? "Valor ainda não publicado pela CLAM" : `Total: ${formatCurrency(price)}`}
+          </p>
+        </section>
+
+        <section className="glass-panel surface-outline space-y-4 rounded-[28px] border border-white/70 p-6 dark:border-white/10">
+          <h2 className="text-xl font-semibold text-slate-950 dark:text-white">Dados de cobrança</h2>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="space-y-2 sm:col-span-2">
+              <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Nome completo *</span>
+              <input
+                required
+                value={payer.name}
+                onChange={(event) => setPayer({ ...payer, name: event.target.value })}
+                className={inputClass}
+              />
+            </label>
+
+            <label className="space-y-2">
+              <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">CPF *</span>
+              <input
+                required
+                inputMode="numeric"
+                value={payer.cpf}
+                onChange={(event) => setPayer({ ...payer, cpf: event.target.value })}
+                className={inputClass}
+                placeholder="000.000.000-00"
+              />
+            </label>
+
+            <label className="space-y-2">
+              <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Celular *</span>
+              <input
+                required
+                inputMode="tel"
+                value={payer.phone}
+                onChange={(event) => setPayer({ ...payer, phone: event.target.value })}
+                className={inputClass}
+                placeholder="(34) 99999-9999"
+              />
+            </label>
+
+            <label className="space-y-2 sm:col-span-2">
+              <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">E-mail *</span>
+              <input
+                required
+                type="email"
+                value={payer.email}
+                onChange={(event) => setPayer({ ...payer, email: event.target.value })}
+                className={inputClass}
+              />
+            </label>
+
+            <label className="space-y-2">
+              <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">CEP *</span>
+              <input
+                required
+                inputMode="numeric"
+                value={payer.zipCode}
+                onChange={(event) => setPayer({ ...payer, zipCode: event.target.value })}
+                className={inputClass}
+                placeholder="38400-000"
+              />
+            </label>
+
+            <label className="space-y-2">
+              <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Bairro *</span>
+              <input
+                required
+                value={payer.neighborhood}
+                onChange={(event) => setPayer({ ...payer, neighborhood: event.target.value })}
+                className={inputClass}
+              />
+            </label>
+
+            <label className="space-y-2">
+              <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Rua *</span>
+              <input
+                required
+                value={payer.street}
+                onChange={(event) => setPayer({ ...payer, street: event.target.value })}
+                className={inputClass}
+              />
+            </label>
+
+            <label className="space-y-2">
+              <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Número *</span>
+              <input
+                required
+                value={payer.number}
+                onChange={(event) => setPayer({ ...payer, number: event.target.value })}
+                className={inputClass}
+              />
+            </label>
+
+            <label className="space-y-2 sm:col-span-2">
+              <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Complemento</span>
+              <input
+                value={payer.complement}
+                onChange={(event) => setPayer({ ...payer, complement: event.target.value })}
+                className={inputClass}
+                placeholder="Apartamento, bloco, referência"
+              />
+            </label>
+          </div>
+
+          <p className="flex items-start gap-2 text-xs text-slate-500 dark:text-slate-400">
+            <ShieldCheck className="mt-0.5 h-4 w-4 flex-none text-blue-600" />
+            Os dados são usados apenas para emitir a cobrança no Mercado Pago. O DADG não armazena dados do
+            seu cartão.
+          </p>
+        </section>
+
+        <button
+          type="submit"
+          disabled={isSubmitting || price === null}
+          className="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-6 py-3.5 text-sm font-semibold text-white disabled:opacity-50"
+        >
+          {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <CreditCard className="h-4 w-4" />}
+          Ir para o pagamento
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/processos-seletivos/[id]/page.tsx
+++ b/app/processos-seletivos/[id]/page.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { useUser } from "@auth0/nextjs-auth0";
+import { ArrowLeft, CalendarDays, Loader2, LogIn, Users } from "lucide-react";
+import {
+  formatDate,
+  STATUS_LABELS,
+  type SelectionProcessDetail,
+  type StudentApplicationState,
+} from "../types";
+
+export default function SelectionProcessPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const processId = params?.id ?? "";
+  const { user, isLoading: isUserLoading } = useUser();
+
+  const [process, setProcess] = useState<SelectionProcessDetail | null>(null);
+  const [state, setState] = useState<StudentApplicationState | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    if (!processId) return;
+
+    setIsLoading(true);
+    setError("");
+
+    try {
+      const detailResponse = await fetch(`/api/v1/selective-processes/${processId}`, { cache: "no-store" });
+      const detailBody = await detailResponse.json().catch(() => ({}));
+      if (!detailResponse.ok || !detailBody?.success) {
+        throw new Error("Processo seletivo não encontrado.");
+      }
+      setProcess(detailBody.data as SelectionProcessDetail);
+
+      if (!user) {
+        setState(null);
+        return;
+      }
+
+      const stateResponse = await fetch(`/api/v1/selective-processes/${processId}/me`, { cache: "no-store" });
+      const stateBody = await stateResponse.json().catch(() => ({}));
+      setState(stateResponse.ok && stateBody?.success ? (stateBody.data as StudentApplicationState) : null);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Erro ao carregar o processo seletivo.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [processId, user]);
+
+  useEffect(() => {
+    if (!isUserLoading) void load();
+  }, [isUserLoading, load]);
+
+  // Regra pedida pela CLAM: ao abrir um processo seletivo o candidato vai direto
+  // para o pagamento (se ainda não pagou) ou para o painel de ligas (se já pagou).
+  useEffect(() => {
+    if (!state) return;
+
+    if (state.status === "PAID_PENDING_LEAGUES" || state.status === "ENROLLED") {
+      router.replace(`/processos-seletivos/${processId}/painel`);
+      return;
+    }
+
+    if (state.canCheckout) {
+      router.replace(`/processos-seletivos/${processId}/inscricao`);
+    }
+  }, [state, processId, router]);
+
+  if (isUserLoading || isLoading) {
+    return (
+      <main className="flex min-h-screen items-center justify-center pt-24">
+        <Loader2 className="h-10 w-10 animate-spin text-blue-600" aria-label="Carregando processo seletivo" />
+      </main>
+    );
+  }
+
+  if (error || !process) {
+    return (
+      <main className="page-shell min-h-screen space-y-6 pb-16 pt-28">
+        <p className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-medium text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+          {error || "Processo seletivo não encontrado."}
+        </p>
+        <Link href="/processos-seletivos" className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600">
+          <ArrowLeft className="h-4 w-4" /> Voltar para a listagem
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page-shell min-h-screen space-y-8 pb-16 pt-28">
+      <Link href="/processos-seletivos" className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600">
+        <ArrowLeft className="h-4 w-4" /> Todos os processos seletivos
+      </Link>
+
+      <header className="glass-panel-strong space-y-4 rounded-3xl border border-white/80 p-6 dark:border-white/10 sm:p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-blue-600">CLAM</p>
+        <h1 className="text-3xl font-bold text-slate-950 dark:text-white sm:text-4xl">
+          Processo seletivo {new Date(process.registrationStartDate).getFullYear()}
+        </h1>
+
+        <ul className="grid gap-2 text-sm text-slate-600 dark:text-slate-300 sm:grid-cols-2">
+          <li className="flex items-start gap-2">
+            <CalendarDays className="mt-0.5 h-4 w-4 flex-none text-blue-600" />
+            Inscrições de {formatDate(process.registrationStartDate)} a {formatDate(process.registrationEndDate)}
+          </li>
+          <li className="flex items-start gap-2">
+            <Users className="mt-0.5 h-4 w-4 flex-none text-blue-600" />
+            {process.remainingCapacity} vaga{process.remainingCapacity === 1 ? "" : "s"} restante
+            {process.remainingCapacity === 1 ? "" : "s"} de {process.maxCapacity}
+          </li>
+        </ul>
+
+        {state && (
+          <p className="w-max rounded-full border border-blue-200 bg-blue-50 px-4 py-1.5 text-xs font-bold text-blue-700 dark:border-blue-900/50 dark:bg-blue-950/40 dark:text-blue-300">
+            {STATUS_LABELS[state.status]}
+          </p>
+        )}
+      </header>
+
+      {!user && (
+        <section className="glass-panel surface-outline flex flex-col gap-4 rounded-[28px] border border-white/70 p-6 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-950 dark:text-white">Entre para se inscrever</h2>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+              Sua inscrição fica vinculada à sua conta do DADG.
+            </p>
+          </div>
+          <a
+            href={`/auth/login?returnTo=${encodeURIComponent(`/processos-seletivos/${processId}`)}`}
+            className="inline-flex w-max items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white"
+          >
+            <LogIn className="h-4 w-4" /> Fazer login
+          </a>
+        </section>
+      )}
+
+      {user && state && !state.canCheckout && !state.canSelectLeagues && state.status !== "ENROLLED" && (
+        <section className="glass-panel surface-outline rounded-[28px] border border-white/70 p-6 dark:border-white/10">
+          <h2 className="text-xl font-semibold text-slate-950 dark:text-white">{STATUS_LABELS[state.status]}</h2>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            {state.status === "REGISTRATION_NOT_OPEN"
+              ? `As inscrições abrem em ${formatDate(process.registrationStartDate)}.`
+              : state.status === "SOLD_OUT"
+                ? "Todas as vagas deste processo seletivo já foram preenchidas."
+                : "O período de inscrições deste processo seletivo já foi encerrado."}
+          </p>
+        </section>
+      )}
+
+      <section className="glass-panel surface-outline rounded-[28px] border border-white/70 p-6 dark:border-white/10">
+        <h2 className="text-2xl font-semibold text-slate-950 dark:text-white">Ligas participantes</h2>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+          As ligas são escolhidas depois da confirmação do pagamento.
+        </p>
+
+        {process.exams.length === 0 ? (
+          <p className="mt-4 rounded-[22px] border border-dashed border-[rgba(9,66,125,0.18)] px-4 py-6 text-sm font-medium text-slate-500 dark:text-slate-400">
+            Nenhuma liga cadastrada neste processo seletivo até o momento.
+          </p>
+        ) : (
+          <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+            {process.exams.map((exam) => (
+              <li
+                key={exam.id}
+                className="rounded-[22px] border border-white/70 bg-white/80 px-4 py-4 dark:border-white/10 dark:bg-slate-900/72"
+              >
+                <p className="font-semibold text-slate-900 dark:text-white">{exam.name}</p>
+                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Prova em {formatDate(exam.examStartDate)}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/app/processos-seletivos/[id]/page.tsx
+++ b/app/processos-seletivos/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useUser } from "@auth0/nextjs-auth0";
 import { ArrowLeft, CalendarDays, Loader2, LogIn, Users } from "lucide-react";
 import {
   formatDate,
+  processYear,
   STATUS_LABELS,
   type SelectionProcessDetail,
   type StudentApplicationState,
@@ -101,7 +102,7 @@ export default function SelectionProcessPage() {
       <header className="glass-panel-strong space-y-4 rounded-3xl border border-white/80 p-6 dark:border-white/10 sm:p-8">
         <p className="text-xs font-semibold uppercase tracking-[0.28em] text-blue-600">CLAM</p>
         <h1 className="text-3xl font-bold text-slate-950 dark:text-white sm:text-4xl">
-          Processo seletivo {new Date(process.registrationStartDate).getFullYear()}
+          Processo seletivo {processYear(process.registrationStartDate)}
         </h1>
 
         <ul className="grid gap-2 text-sm text-slate-600 dark:text-slate-300 sm:grid-cols-2">

--- a/app/processos-seletivos/[id]/painel/page.tsx
+++ b/app/processos-seletivos/[id]/painel/page.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { useUser } from "@auth0/nextjs-auth0";
+import { ArrowLeft, CheckCircle2, Loader2, Lock, LogIn, RefreshCw } from "lucide-react";
+import {
+  describeError,
+  formatCurrency,
+  formatDate,
+  STATUS_LABELS,
+  type StudentApplicationState,
+} from "../../types";
+
+export default function SelectionProcessDashboardPage() {
+  const params = useParams<{ id: string }>();
+  const processId = params?.id ?? "";
+  const { user, isLoading: isUserLoading } = useUser();
+
+  const [state, setState] = useState<StudentApplicationState | null>(null);
+  const [chosenExamIds, setChosenExamIds] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const load = useCallback(async () => {
+    if (!processId || !user) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError("");
+
+    try {
+      const response = await fetch(`/api/v1/selective-processes/${processId}/me`, { cache: "no-store" });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok || !body?.success) {
+        throw new Error(describeError(body?.error, "Não foi possível carregar sua inscrição."));
+      }
+      setState(body.data as StudentApplicationState);
+      setChosenExamIds([]);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Erro ao carregar sua inscrição.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [processId, user]);
+
+  useEffect(() => {
+    if (!isUserLoading) void load();
+  }, [isUserLoading, load]);
+
+  const toggleExam = (examId: string) => {
+    setChosenExamIds((previous) => {
+      if (previous.includes(examId)) return previous.filter((id) => id !== examId);
+      if (state && previous.length >= state.remainingSelections) return previous;
+      return [...previous, examId];
+    });
+  };
+
+  const confirmSelection = async () => {
+    setIsSubmitting(true);
+    setError("");
+    setSuccess("");
+
+    try {
+      const response = await fetch(`/api/v1/selective-processes/${processId}/leagues`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ examIds: chosenExamIds }),
+      });
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok || !body?.success) {
+        throw new Error(describeError(body?.error, "Não foi possível registrar suas ligas."));
+      }
+
+      setState(body.data as StudentApplicationState);
+      setChosenExamIds([]);
+      setSuccess("Ligas registradas com sucesso.");
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : "Erro ao registrar suas ligas.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isUserLoading || isLoading) {
+    return (
+      <main className="flex min-h-screen items-center justify-center pt-24">
+        <Loader2 className="h-10 w-10 animate-spin text-blue-600" aria-label="Carregando painel" />
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="page-shell flex min-h-screen flex-col items-center justify-center gap-5 text-center">
+        <LogIn className="h-12 w-12 text-blue-600" />
+        <h1 className="text-3xl font-bold text-slate-950 dark:text-white">Entre para ver sua inscrição</h1>
+        <a
+          href={`/auth/login?returnTo=${encodeURIComponent(`/processos-seletivos/${processId}/painel`)}`}
+          className="rounded-2xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white"
+        >
+          Fazer login
+        </a>
+      </main>
+    );
+  }
+
+  if (!state) {
+    return (
+      <main className="page-shell min-h-screen space-y-6 pb-16 pt-28">
+        <p className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-medium text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+          {error || "Não foi possível carregar sua inscrição."}
+        </p>
+        <Link href="/processos-seletivos" className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600">
+          <ArrowLeft className="h-4 w-4" /> Voltar para a listagem
+        </Link>
+      </main>
+    );
+  }
+
+  const isPaid = state.ticket?.paymentStatus === "PAID";
+  const selectedSet = new Set(state.selectedExamIds);
+
+  return (
+    <main className="page-shell min-h-screen space-y-8 pb-16 pt-28">
+      <Link
+        href={`/processos-seletivos/${processId}`}
+        className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600"
+      >
+        <ArrowLeft className="h-4 w-4" /> Voltar ao processo seletivo
+      </Link>
+
+      <header className="glass-panel-strong flex flex-col gap-5 rounded-3xl border border-white/80 p-6 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-8">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-blue-600">Minha inscrição</p>
+          <h1 className="mt-2 text-3xl font-bold text-slate-950 dark:text-white">
+            Processo seletivo {new Date(state.process.registrationStartDate).getFullYear()}
+          </h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{STATUS_LABELS[state.status]}</p>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="inline-flex w-max items-center gap-2 rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-sm font-semibold text-slate-700 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-200"
+        >
+          <RefreshCw className="h-4 w-4" /> Atualizar
+        </button>
+      </header>
+
+      {state.ticket && (
+        <section className="glass-panel surface-outline grid gap-4 rounded-[28px] border border-white/70 p-6 dark:border-white/10 sm:grid-cols-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">Pagamento</p>
+            <p className="mt-1 text-lg font-bold text-slate-900 dark:text-white">
+              {isPaid ? "Confirmado" : state.ticket.paymentStatus === "CANCELED" ? "Cancelado" : "Pendente"}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">Valor</p>
+            <p className="mt-1 text-lg font-bold text-slate-900 dark:text-white">
+              {formatCurrency(state.ticket.totalAmount)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">Ligas contratadas</p>
+            <p className="mt-1 text-lg font-bold text-slate-900 dark:text-white">
+              {state.selectedExamIds.length} de {state.ticket.leagueAllowanceCount}
+            </p>
+          </div>
+        </section>
+      )}
+
+      {!isPaid && (
+        <section className="rounded-[28px] border border-amber-200 bg-amber-50 p-6 dark:border-amber-900/50 dark:bg-amber-950/30">
+          <h2 className="text-lg font-semibold text-amber-800 dark:text-amber-200">Pagamento ainda não confirmado</h2>
+          <p className="mt-1 text-sm text-amber-700 dark:text-amber-300">
+            A escolha das ligas é liberada assim que o Mercado Pago confirmar o pagamento. A confirmação pode
+            levar alguns minutos.
+          </p>
+          <Link
+            href={`/processos-seletivos/${processId}/inscricao`}
+            className="mt-4 inline-flex items-center gap-2 rounded-2xl bg-amber-600 px-5 py-3 text-sm font-semibold text-white"
+          >
+            Ver pagamento
+          </Link>
+        </section>
+      )}
+
+      {error && (
+        <p className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-medium text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm font-medium text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/30 dark:text-emerald-300">
+          {success}
+        </p>
+      )}
+
+      <section className="glass-panel surface-outline rounded-[28px] border border-white/70 p-6 dark:border-white/10">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-950 dark:text-white">Ligas acadêmicas disponíveis</h2>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+              {isPaid
+                ? state.remainingSelections > 0
+                  ? `Escolha ${state.remainingSelections} liga${state.remainingSelections === 1 ? "" : "s"}. A escolha é definitiva.`
+                  : "Você já registrou todas as ligas da sua inscrição."
+                : "Disponível após a confirmação do pagamento."}
+            </p>
+          </div>
+
+          {isPaid && state.remainingSelections > 0 && (
+            <button
+              type="button"
+              onClick={() => void confirmSelection()}
+              disabled={isSubmitting || chosenExamIds.length === 0}
+              className="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white disabled:opacity-50"
+            >
+              {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+              Confirmar {chosenExamIds.length || ""} liga{chosenExamIds.length === 1 ? "" : "s"}
+            </button>
+          )}
+        </div>
+
+        {state.process.exams.length === 0 ? (
+          <p className="mt-5 rounded-[22px] border border-dashed border-[rgba(9,66,125,0.18)] px-4 py-8 text-center text-sm font-medium text-slate-500 dark:text-slate-400">
+            Nenhuma liga cadastrada neste processo seletivo até o momento.
+          </p>
+        ) : (
+          <ul className="mt-5 grid gap-3 sm:grid-cols-2">
+            {state.process.exams.map((exam) => {
+              const alreadySelected = selectedSet.has(exam.id);
+              const isChosen = chosenExamIds.includes(exam.id);
+              const canToggle = isPaid && !alreadySelected && state.remainingSelections > 0;
+
+              return (
+                <li key={exam.id}>
+                  <button
+                    type="button"
+                    onClick={() => canToggle && toggleExam(exam.id)}
+                    disabled={!canToggle}
+                    className={`w-full rounded-[22px] border px-4 py-4 text-left transition-transform duration-300 ${
+                      alreadySelected
+                        ? "border-emerald-200 bg-emerald-50 dark:border-emerald-900/50 dark:bg-emerald-950/30"
+                        : isChosen
+                          ? "border-blue-600 bg-blue-50 dark:border-blue-500 dark:bg-blue-950/40"
+                          : "border-white/70 bg-white/80 dark:border-white/10 dark:bg-slate-900/72"
+                    } ${canToggle ? "hover:-translate-y-0.5" : "cursor-default opacity-90"}`}
+                  >
+                    <span className="flex items-start justify-between gap-3">
+                      <span>
+                        <span className="block font-semibold text-slate-900 dark:text-white">{exam.name}</span>
+                        <span className="mt-1 block text-xs text-slate-500 dark:text-slate-400">
+                          Prova em {formatDate(exam.examStartDate)}
+                        </span>
+                      </span>
+
+                      {alreadySelected ? (
+                        <span className="inline-flex flex-none items-center gap-1 rounded-full bg-emerald-100 px-2.5 py-1 text-[11px] font-bold text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300">
+                          <Lock className="h-3 w-3" /> Confirmada
+                        </span>
+                      ) : isChosen ? (
+                        <CheckCircle2 className="h-5 w-5 flex-none text-blue-600" />
+                      ) : null}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/app/processos-seletivos/[id]/painel/page.tsx
+++ b/app/processos-seletivos/[id]/painel/page.tsx
@@ -9,6 +9,7 @@ import {
   describeError,
   formatCurrency,
   formatDate,
+  processYear,
   STATUS_LABELS,
   type StudentApplicationState,
 } from "../../types";
@@ -140,7 +141,7 @@ export default function SelectionProcessDashboardPage() {
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.28em] text-blue-600">Minha inscrição</p>
           <h1 className="mt-2 text-3xl font-bold text-slate-950 dark:text-white">
-            Processo seletivo {new Date(state.process.registrationStartDate).getFullYear()}
+            Processo seletivo {processYear(state.process.registrationStartDate)}
           </h1>
           <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{STATUS_LABELS[state.status]}</p>
         </div>

--- a/app/processos-seletivos/layout.tsx
+++ b/app/processos-seletivos/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Processos seletivos das ligas acadêmicas | DADG",
+  description:
+    "Consulte os processos seletivos da CLAM, faça sua inscrição e escolha as ligas acadêmicas de medicina em que quer concorrer.",
+  openGraph: {
+    title: "Processos seletivos das ligas acadêmicas | DADG",
+    description:
+      "Consulte os processos seletivos da CLAM, faça sua inscrição e escolha as ligas acadêmicas de medicina em que quer concorrer.",
+    type: "website",
+  },
+};
+
+export default function SelectionProcessesLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/processos-seletivos/page.tsx
+++ b/app/processos-seletivos/page.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CalendarDays, GraduationCap, Loader2, RefreshCw, Search, Users } from "lucide-react";
+import { formatDate, type SelectionProcessSummary } from "./types";
+
+function statusBadge(process: SelectionProcessSummary) {
+  if (!process.hasStarted) {
+    return { label: "Em breve", className: "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/50 dark:bg-sky-950/40 dark:text-sky-300" };
+  }
+  if (process.hasEnded) {
+    return { label: "Encerrado", className: "border-slate-200 bg-slate-100 text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300" };
+  }
+  if (process.remainingCapacity <= 0) {
+    return { label: "Vagas esgotadas", className: "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-300" };
+  }
+  return { label: "Inscrições abertas", className: "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-300" };
+}
+
+export default function SelectionProcessesPage() {
+  const [processes, setProcesses] = useState<SelectionProcessSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
+  const [onlyOpen, setOnlyOpen] = useState(false);
+
+  const loadProcesses = useCallback(async () => {
+    setIsLoading(true);
+    setError("");
+
+    try {
+      const response = await fetch("/api/v1/selective-processes", { cache: "no-store" });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok || !body?.success) {
+        throw new Error("Não foi possível carregar os processos seletivos.");
+      }
+      setProcesses(Array.isArray(body.data) ? body.data : []);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Erro ao carregar os processos seletivos.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadProcesses();
+  }, [loadProcesses]);
+
+  const visibleProcesses = useMemo(() => {
+    const term = search.trim().toLowerCase();
+
+    return processes.filter((process) => {
+      if (onlyOpen && !process.isRegistrationOpen) return false;
+      if (!term) return true;
+
+      const haystack = [
+        formatDate(process.registrationStartDate),
+        formatDate(process.registrationEndDate),
+        new Date(process.registrationStartDate).getFullYear().toString(),
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(term);
+    });
+  }, [processes, search, onlyOpen]);
+
+  return (
+    <main className="page-shell min-h-screen space-y-8 pb-16 pt-28">
+      <header className="glass-panel-strong rounded-3xl border border-white/80 p-6 dark:border-white/10 sm:p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-blue-600">CLAM</p>
+        <h1 className="mt-2 text-3xl font-bold text-slate-950 dark:text-white sm:text-4xl">
+          Processos seletivos das ligas acadêmicas
+        </h1>
+        <p className="mt-3 max-w-3xl leading-7 text-slate-600 dark:text-slate-300">
+          Consulte os processos seletivos abertos pela Coordenadoria de Ligas Acadêmicas de Medicina, faça a
+          inscrição e escolha as ligas em que quer concorrer.
+        </p>
+      </header>
+
+      <section className="glass-panel surface-outline flex flex-col gap-4 rounded-[28px] border border-white/70 p-5 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between">
+        <label className="relative flex-1">
+          <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Buscar por período ou ano"
+            className="w-full rounded-2xl border border-white/70 bg-white/80 py-3 pl-11 pr-4 text-sm text-slate-800 outline-none focus:ring-2 focus:ring-blue-600 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100"
+          />
+        </label>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="inline-flex cursor-pointer items-center gap-2 rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-sm font-semibold text-slate-700 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-200">
+            <input
+              type="checkbox"
+              checked={onlyOpen}
+              onChange={(event) => setOnlyOpen(event.target.checked)}
+              className="h-4 w-4 accent-blue-600"
+            />
+            Só inscrições abertas
+          </label>
+
+          <button
+            type="button"
+            onClick={() => void loadProcesses()}
+            className="inline-flex items-center gap-2 rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-sm font-semibold text-slate-700 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-200"
+          >
+            <RefreshCw className="h-4 w-4" /> Atualizar
+          </button>
+        </div>
+      </section>
+
+      {error && (
+        <p className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-medium text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+          {error}
+        </p>
+      )}
+
+      {isLoading ? (
+        <div className="flex justify-center py-20">
+          <Loader2 className="h-10 w-10 animate-spin text-blue-600" aria-label="Carregando processos seletivos" />
+        </div>
+      ) : visibleProcesses.length === 0 ? (
+        <p className="rounded-[28px] border border-dashed border-[rgba(9,66,125,0.18)] bg-white/72 px-6 py-12 text-center text-sm font-medium text-slate-500 dark:bg-slate-900/68 dark:text-slate-400">
+          {processes.length === 0
+            ? "Nenhum processo seletivo cadastrado no momento."
+            : "Nenhum processo seletivo corresponde ao filtro aplicado."}
+        </p>
+      ) : (
+        <div className="grid gap-5 lg:grid-cols-2">
+          {visibleProcesses.map((process) => {
+            const badge = statusBadge(process);
+
+            return (
+              <article
+                key={process.id}
+                className="glass-panel surface-outline flex flex-col justify-between gap-5 rounded-[28px] border border-white/70 p-6 dark:border-white/10"
+              >
+                <div className="space-y-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <span className={`rounded-full border px-3 py-1 text-xs font-bold ${badge.className}`}>
+                      {badge.label}
+                    </span>
+                    <span className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+                      {process.examsCount} liga{process.examsCount === 1 ? "" : "s"}
+                    </span>
+                  </div>
+
+                  <h2 className="text-2xl font-semibold text-slate-950 dark:text-white">
+                    Processo seletivo {new Date(process.registrationStartDate).getFullYear()}
+                  </h2>
+
+                  <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                    <li className="flex items-start gap-2">
+                      <CalendarDays className="mt-0.5 h-4 w-4 flex-none text-blue-600" />
+                      Inscrições de {formatDate(process.registrationStartDate)} a {formatDate(process.registrationEndDate)}
+                    </li>
+                    <li className="flex items-start gap-2">
+                      <Users className="mt-0.5 h-4 w-4 flex-none text-blue-600" />
+                      {process.paidCount} de {process.maxCapacity} vagas preenchidas
+                    </li>
+                    <li className="flex items-start gap-2">
+                      <GraduationCap className="mt-0.5 h-4 w-4 flex-none text-blue-600" />
+                      Até {process.maxExamsPerApplication} liga{process.maxExamsPerApplication === 1 ? "" : "s"} por inscrição
+                    </li>
+                  </ul>
+                </div>
+
+                <Link
+                  href={`/processos-seletivos/${process.id}`}
+                  className="inline-flex w-max items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white transition-transform duration-300 hover:-translate-y-0.5"
+                >
+                  Ver processo seletivo
+                </Link>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/processos-seletivos/page.tsx
+++ b/app/processos-seletivos/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CalendarDays, GraduationCap, Loader2, RefreshCw, Search, Users } from "lucide-react";
-import { formatDate, type SelectionProcessSummary } from "./types";
+import { formatDate, processYear, type SelectionProcessSummary } from "./types";
 
 function statusBadge(process: SelectionProcessSummary) {
   if (!process.hasStarted) {
@@ -57,7 +57,7 @@ export default function SelectionProcessesPage() {
       const haystack = [
         formatDate(process.registrationStartDate),
         formatDate(process.registrationEndDate),
-        new Date(process.registrationStartDate).getFullYear().toString(),
+        processYear(process.registrationStartDate).toString(),
       ]
         .join(" ")
         .toLowerCase();
@@ -149,7 +149,7 @@ export default function SelectionProcessesPage() {
                   </div>
 
                   <h2 className="text-2xl font-semibold text-slate-950 dark:text-white">
-                    Processo seletivo {new Date(process.registrationStartDate).getFullYear()}
+                    Processo seletivo {processYear(process.registrationStartDate)}
                   </h2>
 
                   <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-300">

--- a/app/processos-seletivos/types.ts
+++ b/app/processos-seletivos/types.ts
@@ -89,12 +89,20 @@ export function formatCurrency(value: number) {
   return value.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 }
 
+// As datas do processo seletivo sao gravadas a meia-noite UTC. Formatar no fuso
+// local jogaria "2026-01-01" para 31/12/2025 no Brasil, entao tudo aqui e lido
+// em UTC.
 export function formatDate(value: string) {
   return new Date(value).toLocaleDateString("pt-BR", {
     day: "2-digit",
     month: "long",
     year: "numeric",
+    timeZone: "UTC",
   });
+}
+
+export function processYear(value: string) {
+  return new Date(value).getUTCFullYear();
 }
 
 export function formatDateTime(value: string) {

--- a/app/processos-seletivos/types.ts
+++ b/app/processos-seletivos/types.ts
@@ -1,0 +1,108 @@
+export type SelectionProcessSummary = {
+  id: string;
+  registrationStartDate: string;
+  registrationEndDate: string;
+  maxExamsPerApplication: number;
+  maxCapacity: number;
+  paidCount: number;
+  remainingCapacity: number;
+  examsCount: number;
+  hasStarted: boolean;
+  hasEnded: boolean;
+  isRegistrationOpen: boolean;
+};
+
+export type SelectionProcessExam = {
+  id: string;
+  name: string;
+  examStartDate: string;
+  examEndDate: string;
+};
+
+export type SelectionProcessPricingTier = {
+  examsCount: number;
+  unitTotalPrice: number;
+};
+
+export type SelectionProcessDetail = SelectionProcessSummary & {
+  exams: SelectionProcessExam[];
+  pricingTiers: SelectionProcessPricingTier[];
+};
+
+export type StudentApplicationStatus =
+  | "REGISTRATION_NOT_OPEN"
+  | "REGISTRATION_CLOSED"
+  | "SOLD_OUT"
+  | "NOT_REGISTERED"
+  | "PAYMENT_PENDING"
+  | "PAID_PENDING_LEAGUES"
+  | "ENROLLED";
+
+export type StudentApplicationState = {
+  process: SelectionProcessDetail;
+  status: StudentApplicationStatus;
+  canCheckout: boolean;
+  canSelectLeagues: boolean;
+  application: { id: string; finalStatus: string } | null;
+  ticket: {
+    id: string;
+    paymentStatus: "PENDING" | "PAID" | "CANCELED";
+    totalAmount: number;
+    leagueAllowanceCount: number;
+  } | null;
+  payment: { sessionId: string; init_point: string; expiresAt: string } | null;
+  selectedExamIds: string[];
+  remainingSelections: number;
+};
+
+export const STATUS_LABELS: Record<StudentApplicationStatus, string> = {
+  REGISTRATION_NOT_OPEN: "Inscrições ainda não abriram",
+  REGISTRATION_CLOSED: "Inscrições encerradas",
+  SOLD_OUT: "Vagas esgotadas",
+  NOT_REGISTERED: "Inscrições abertas",
+  PAYMENT_PENDING: "Pagamento pendente",
+  PAID_PENDING_LEAGUES: "Pagamento confirmado — escolha suas ligas",
+  ENROLLED: "Inscrição concluída",
+};
+
+const CHECKOUT_ERROR_MESSAGES: Record<string, string> = {
+  REGISTRATION_CLOSED: "O período de inscrições deste processo seletivo não está aberto.",
+  SOLD_OUT: "As vagas deste processo seletivo se esgotaram.",
+  ALREADY_ENROLLED: "Você já possui inscrição neste processo seletivo.",
+  EXAMS_EXCEED_MAX_PER_APPLICATION: "Você escolheu mais ligas do que este processo seletivo permite.",
+  PRICING_NOT_CONFIGURED: "A tabela de preços ainda não foi publicada pela CLAM. Tente novamente mais tarde.",
+  INVALID_PAYER: "Confira os dados de cobrança: algum campo obrigatório está vazio.",
+  INVALID_EXAMS_COUNT: "Escolha ao menos uma liga para se inscrever.",
+  PAYMENT_NOT_CONFIRMED: "Seu pagamento ainda não foi confirmado pelo Mercado Pago.",
+  LEAGUE_ALLOWANCE_EXCEEDED: "Você selecionou mais ligas do que pagou.",
+  LEAGUES_ALREADY_SELECTED: "Essas ligas já foram registradas na sua inscrição.",
+  EXAMS_INVALID_FOR_PROCESS: "Alguma das ligas escolhidas não pertence a este processo seletivo.",
+  NOT_AUTHENTICATED: "Entre na sua conta para continuar.",
+};
+
+export function describeError(code: string | undefined, fallback: string) {
+  if (!code) return fallback;
+  return CHECKOUT_ERROR_MESSAGES[code] || fallback;
+}
+
+export function formatCurrency(value: number) {
+  return value.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+}
+
+export function formatDate(value: string) {
+  return new Date(value).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export function formatDateTime(value: string) {
+  return new Date(value).toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}


### PR DESCRIPTION
> **Depende de** TeteuTias/dadg-certificates PR "feat(selective-processes): API de inscrição do candidato", que expõe as rotas `/api/v1/selective-processes` consumidas aqui. Sem ele as telas carregam mas não encontram dados.

## Telas

**`/processos-seletivos`** — listagem de todos os processos seletivos da CLAM, com busca por período/ano, filtro de "só inscrições abertas" e, em cada card, o estado (em breve / abertas / esgotado / encerrado), as datas, a ocupação das vagas e o limite de ligas por inscrição.

**`/processos-seletivos/[id]`** — valida a situação do candidato antes de qualquer coisa e encaminha:

- não inscrito e inscrições abertas → `/inscricao` (pagamento);
- pagamento confirmado → `/painel` (ligas);
- fora do período ou esgotado → explica o motivo na própria tela;
- deslogado → convite para entrar, mantendo `returnTo`.

**`/processos-seletivos/[id]/inscricao`** — escolha de quantas ligas disputar (respeitando `maxExamsPerApplication`), dados de cobrança e redirecionamento para o Checkout Pro. Se já existe um pagamento em aberto, a tela oferece retomar o link em vez de gerar outro.

**`/processos-seletivos/[id]/painel`** — acesso pós-pagamento: resumo do pagamento, todas as ligas do processo seletivo, quantas ainda podem ser escolhidas e quais já estão travadas. A confirmação é definitiva, e a tela deixa isso explícito antes do envio.

## Detalhes

- O valor da inscrição não é enviado pelo cliente: a tela só exibe o preço vindo da tabela de faixas, e o backend recalcula na hora de gerar a cobrança.
- Identidade visual seguindo o restante do site (`page-shell`, `glass-panel`, `surface-outline`, cantos `28px`, azul `blue-600`, dark mode).
- Metadata e Open Graph próprios em `app/processos-seletivos/layout.tsx`.
- Mensagens de erro traduzidas por código (`ALREADY_ENROLLED`, `SOLD_OUT`, `LEAGUE_ALLOWANCE_EXCEEDED`...) em vez de repassar o código cru.
- Atalhos para a listagem na página da CLAM e no painel do usuário.

## Como testar

1. Deslogado, abrir `/processos-seletivos` e entrar em um processo seletivo — deve pedir login.
2. Logado e sem inscrição, com período aberto — deve cair direto na tela de pagamento.
3. Gerar a cobrança e pagar em ambiente de teste; após o webhook, reabrir o processo seletivo — deve cair no painel de ligas.
4. Escolher ligas até o limite pago e confirmar que as já travadas não podem ser alteradas.