### PR TITLE
fix(mobile): tirar o card de programação de trás da barra de navegação

### DIFF
--- a/app/components/UpcomingSchedulePopup.tsx
+++ b/app/components/UpcomingSchedulePopup.tsx
@@ -115,7 +115,10 @@ export default function UpcomingSchedulePopup() {
   return (
     <aside
       className={cn(
-        "relative fixed bottom-3 right-3 z-[60] max-h-[calc(100vh-6.5rem)] w-[min(86vw,320px)] overflow-hidden rounded-[24px] border border-slate-200 bg-white p-3 shadow-[0_20px_60px_rgba(7,48,89,0.18)] dark:border-slate-800 dark:bg-slate-950",
+        // No mobile o card precisa ficar acima da barra de navegacao fixa
+        // (MobileBottomNav, ~4rem + safe area, z-[1002]). A partir de md a barra
+        // some e o card volta a encostar no rodape.
+        "fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-3 z-[1001] max-h-[calc(100vh-11rem)] w-[min(86vw,320px)] overflow-hidden rounded-[24px] border border-slate-200 bg-white p-3 shadow-[0_20px_60px_rgba(7,48,89,0.18)] md:bottom-3 md:max-h-[calc(100vh-6.5rem)] dark:border-slate-800 dark:bg-slate-950",
         expanded ? "space-y-3" : "space-y-0"
       )}
     >
@@ -162,7 +165,7 @@ export default function UpcomingSchedulePopup() {
       </div>
 
       {expanded ? (
-        <div className="max-h-[min(18rem,calc(100vh-10rem))] space-y-3 overflow-y-auto border-t border-[rgba(9,66,125,0.08)] pt-3 pr-1">
+        <div className="max-h-[min(18rem,calc(100vh-15rem))] space-y-3 overflow-y-auto border-t border-[rgba(9,66,125,0.08)] pt-3 pr-1 md:max-h-[min(18rem,calc(100vh-10rem))]">
           <div className="flex items-center justify-between gap-3">
             <p className="text-xs leading-5 text-slate-600 dark:text-slate-300">
               Resumo rapido antes de abrir o calendario.


### PR DESCRIPTION
## Problema

No mobile, o card "Programação — Próximas duas semanas" ficava atrás da barra de navegação inferior. As datas e os botões de expandir e fechar ficavam encobertos, e não dava para interagir com eles.

A causa são dois elementos fixos brigando:

| Elemento | Posição | z-index |
| --- | --- | --- |
| `UpcomingSchedulePopup` | `bottom-3` | `z-[60]` |
| `MobileBottomNav` | `bottom-0` (altura 68px) | `z-[1002]` |

O card terminava dentro da faixa ocupada pela barra e, com z-index menor, ficava por baixo.

## Correção

O card passa a se apoiar acima da barra, respeitando a safe area do iPhone:

```
bottom-[calc(5rem+env(safe-area-inset-bottom))] z-[1001] md:bottom-3
```

A partir de `md` a barra some (`md:hidden`) e o card volta a `bottom-3`, como era antes — o desktop não muda.

A altura máxima também desconta a barra no mobile (`max-h-[calc(100vh-11rem)]`, e `max-h-[min(18rem,calc(100vh-15rem))]` na lista interna), para o card expandido não crescer por baixo dela.

Removi ainda a classe `relative` que vinha junto de `fixed` no mesmo elemento: as duas definem `position` e qual valia dependia da ordem no CSS gerado.

## Medições

Em 375×812, medindo os elementos na página:

| | antes | depois |
| --- | --- | --- |
| Fim do card | 800px | 732px |
| Topo da barra | 744px | 744px |
| Sobreposição | 56px | nenhuma (12px de folga) |

Expandido: card de 310px de altura, topo em 422px, fim em 732px — inteiro visível, sem sobrepor a barra e sem cortar no topo. Sem scroll horizontal.

Em 1280px: card a 12px do rodapé e barra mobile oculta, igual ao comportamento atual.